### PR TITLE
fixed help link - now it points to mate-user-guide

### DIFF
--- a/Mozo/MainWindow.py
+++ b/Mozo/MainWindow.py
@@ -599,7 +599,7 @@ class MainWindow:
 		self.editor.redo()
 
 	def on_help_button_clicked(self, *args):
-		gtk.show_uri(gtk.gdk.screen_get_default(), "http://wiki.mate-desktop.org/docs:mozo", gtk.get_current_event_time())
+		gtk.show_uri(gtk.gdk.screen_get_default(), "help:mate-user-guide/menu-editor", gtk.get_current_event_time())
 
 	def on_revert_button_clicked(self, button):
 		dialog = self.tree.get_object('revertdialog')


### PR DESCRIPTION
please note though that the guide only mentions "menubar" editing,
while all other menu types can be freely edited with Mozo as well -
since they all use the same set of items under the hood.