### PR TITLE
fix wrong highlighting while moving menu items

### DIFF
--- a/Mozo/MainWindow.py
+++ b/Mozo/MainWindow.py
@@ -128,6 +128,8 @@ class MainWindow:
 						found = True
 				if item[3].get_type() == matemenu.TYPE_SEPARATOR:
 					if not isinstance(item_id, tuple):
+						#we may not skip the increment via "continue"
+						i += 1
 						continue
 					#separators have no id, have to find them manually
 					#probably won't work with two separators together


### PR DESCRIPTION
when separators are present.

fixes https://github.com/mate-desktop/mozo/issues/16