### PR TITLE
Fix menu entry can not move

### DIFF
--- a/Mozo/MainWindow.py
+++ b/Mozo/MainWindow.py
@@ -593,7 +593,7 @@ class MainWindow:
         item = items[path][3]
         before = items[(path.get_indices()[0] - 1,)][3]
         if isinstance(item, MateMenu.TreeEntry):
-            self.editor.moveItem(item, item.get_parent(), before=before)
+            self.editor.moveItem(item.get_parent(), item, before=before)
         elif isinstance(item, MateMenu.TreeDirectory):
             self.editor.moveMenu(item, item.get_parent(), before=before)
         elif isinstance(item, MateMenu.TreeSeparator):
@@ -611,7 +611,7 @@ class MainWindow:
         item = items[path][3]
         after = items[path][3]
         if isinstance(item, MateMenu.TreeEntry):
-            self.editor.moveItem(item, item.get_parent(), after=after)
+            self.editor.moveItem(item.get_parent(), item, after=after)
         elif isinstance(item, MateMenu.TreeDirectory):
             self.editor.moveMenu(item, item.get_parent(), after=after)
         elif isinstance(item, MateMenu.TreeSeparator):


### PR DESCRIPTION
Menu entry can't move, and got the error:
```
Traceback (most recent call last):
  File "/usr/lib/python3.7/dist-packages/Mozo/MainWindow.py", line 596, in on_move_up_button_clicked
    self.editor.moveItem(item, item.get_parent(), before=before)
  File "/usr/lib/python3.7/dist-packages/Mozo/MenuEditor.py", line 756, in moveItem
    self.__positionItem(parent, item, before=before, after=after)
  File "/usr/lib/python3.7/dist-packages/Mozo/MenuEditor.py", line 760, in __positionItem
    contents = self.getContents(parent)
  File "/usr/lib/python3.7/dist-packages/Mozo/MenuEditor.py", line 243, in getContents
    item_iter = item.iter()
AttributeError: 'TreeEntry' object has no attribute 'iter'
```