### PR TITLE
Change url project's website

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl -*- Mode: autoconf -*-
 dnl Process this file with autoconf to produce a configure script.
 AC_PREREQ(2.53)
-AC_INIT(mozo, 1.23.0, http://www.mate-desktop.org)
+AC_INIT(mozo, 1.23.0, https://mate-desktop.org)
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 AC_CONFIG_SRCDIR(mozo.in)
 AC_CONFIG_HEADERS([config.h])


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.