### PR TITLE
Fix item drag & drop creating copies, fix undo, redo and a crash when refreshing

### DIFF
--- a/Mozo/MainWindow.py
+++ b/Mozo/MainWindow.py
@@ -184,7 +184,7 @@ class MainWindow:
         column.add_attribute(cell, 'markup', 1)
         column.set_sizing(Gtk.TreeViewColumnSizing.FIXED)
         menus.append_column(column)
-        menus.enable_model_drag_source(Gdk.ModifierType.BUTTON1_MASK, self.dnd_menus, Gdk.DragAction.COPY)
+        menus.enable_model_drag_source(Gdk.ModifierType.BUTTON1_MASK, self.dnd_menus, Gdk.DragAction.MOVE)
         menus.enable_model_drag_dest(self.dnd_both, Gdk.DragAction.PRIVATE)
         menus.get_selection().set_mode(Gtk.SelectionMode.BROWSE)
 
@@ -210,7 +210,7 @@ class MainWindow:
         items.append_column(column)
         self.item_store = Gtk.ListStore(bool, GdkPixbuf.Pixbuf, str, object)
         items.set_model(self.item_store)
-        items.enable_model_drag_source(Gdk.ModifierType.BUTTON1_MASK, self.dnd_items, Gdk.DragAction.COPY)
+        items.enable_model_drag_source(Gdk.ModifierType.BUTTON1_MASK, self.dnd_items, Gdk.DragAction.MOVE)
         items.enable_model_drag_dest(self.dnd_items, Gdk.DragAction.PRIVATE)
 
     def _cell_data_toggle_func(self, tree_column, renderer, model, treeiter, data=None):

--- a/Mozo/MainWindow.py
+++ b/Mozo/MainWindow.py
@@ -98,7 +98,7 @@ class MainWindow:
         update_items = False
         update_type = None
         item_id = None
-        if iter:
+        if iter and items[iter][3].get_desktop_file_path():
             update_items = True
             if isinstance(items[iter][3], MateMenu.TreeDirectory):
                 item_id = os.path.split(items[iter][3].get_desktop_file_path())[1]
@@ -425,7 +425,7 @@ class MainWindow:
                 item = self.drag_data
                 new_parent = menus[path][2]
                 if isinstance(item, MateMenu.TreeEntry):
-                    self.editor.copyItem(item, new_parent)
+                    self.editor.moveItem(item, new_parent)
                 elif isinstance(item, MateMenu.TreeDirectory):
                     if not self.editor.moveMenu(item, new_parent):
                         self.loadUpdates()
@@ -593,7 +593,7 @@ class MainWindow:
         item = items[path][3]
         before = items[(path.get_indices()[0] - 1,)][3]
         if isinstance(item, MateMenu.TreeEntry):
-            self.editor.moveItem(item.get_parent(), item, before=before)
+            self.editor.moveItem(item, item.get_parent(), before=before)
         elif isinstance(item, MateMenu.TreeDirectory):
             self.editor.moveMenu(item, item.get_parent(), before=before)
         elif isinstance(item, MateMenu.TreeSeparator):
@@ -611,7 +611,7 @@ class MainWindow:
         item = items[path][3]
         after = items[path][3]
         if isinstance(item, MateMenu.TreeEntry):
-            self.editor.moveItem(item.get_parent(), item, after=after)
+            self.editor.moveItem(item, item.get_parent(), after=after)
         elif isinstance(item, MateMenu.TreeDirectory):
             self.editor.moveMenu(item, item.get_parent(), after=after)
         elif isinstance(item, MateMenu.TreeSeparator):

--- a/Mozo/MenuEditor.py
+++ b/Mozo/MenuEditor.py
@@ -411,17 +411,18 @@ class MenuEditor(object):
         undo = []
         if item.get_parent() != new_parent:
             # create new item
-            file_id = self.copyItem(item, new_parent)
+            self.copyItem(item, new_parent)
             # hide old item
             self.deleteItem(item)
-            item = ('Item', file_id)
-        self.__positionItem(new_parent, item, before, after)
+        else:
+            self.__positionItem(new_parent, item, before, after)
         undo.append(self.__getMenu(new_parent))
         self.__addUndo(undo)
-        # merge the undo entries created by the previous operations in the
-        # correct order so we can undo in one go
-        items = self.__undo.pop()[::-1] + self.__undo.pop()[::-1] + self.__undo.pop()[::-1]
-        self.__undo.append(items[::-1])
+        if item.get_parent() != new_parent:
+            # merge the undo entries created by the previous operations in the
+            # correct order so we can undo in one go
+            items = self.__undo.pop()[::-1] + self.__undo.pop()[::-1] + self.__undo.pop()[::-1]
+            self.__undo.append(items[::-1])
         self.save()
 
     def moveMenu(self, menu, new_parent, before=None, after=None):

--- a/Mozo/MenuEditor.py
+++ b/Mozo/MenuEditor.py
@@ -168,19 +168,27 @@ class MenuEditor(object):
         redo = []
         for undo_path in files[::-1]:
             new_path = undo_path.rsplit('.', 1)[0]
+            if not os.path.exists(undo_path):
+                continue
             redo_path = util.getUniqueRedoFile(new_path)
 
             # create redo file
-            with codecs.open(new_path, 'r', 'utf-8') as f_new:
-                with codecs.open(redo_path, 'w', 'utf-8') as f_redo:
-                    f_redo.write(f_new.read())
-            redo.append(redo_path)
+            try:
+                with codecs.open(new_path, 'r', 'utf-8') as f_new:
+                    with codecs.open(redo_path, 'w', 'utf-8') as f_redo:
+                        f_redo.write(f_new.read())
+                redo.append(redo_path)
+            except FileNotFoundError:
+                pass
 
             # restore undo file
-            with codecs.open(undo_path, 'r', 'utf-8') as f_undo:
-                with codecs.open(new_path, 'w', 'utf-8') as f_new:
-                    f_new.write(f_undo.read())
-            os.unlink(undo_path)
+            try:
+                with codecs.open(undo_path, 'r', 'utf-8') as f_undo:
+                    with codecs.open(new_path, 'w', 'utf-8') as f_new:
+                        f_new.write(f_undo.read())
+                os.unlink(undo_path)
+            except FileNotFoundError:
+                pass
 
         # reload DOM to make changes stick
         for name in ('applications', 'settings'):
@@ -190,7 +198,8 @@ class MenuEditor(object):
             except (IOError, xml.parsers.expat.ExpatError):
                 menu.dom = xml.dom.minidom.parseString(util.getUserMenuXml(menu.tree))
             util.removeWhitespaceNodes(menu.dom)
-        self.__redo.append(redo)
+        if redo:
+            self.__redo.append(redo)
 
     def redo(self):
         if len(self.__redo) == 0:
@@ -199,19 +208,27 @@ class MenuEditor(object):
         undo = []
         for redo_path in files[::-1]:
             new_path = redo_path.rsplit('.', 1)[0]
+            if not os.path.exists(redo_path):
+                continue
             undo_path = util.getUniqueUndoFile(new_path)
 
             # create undo file
-            with codecs.open(new_path, 'r', 'utf-8') as f_new:
-                with codecs.open(undo_path, 'w', 'utf-8') as f_undo:
-                    f_undo.write(f_new.read())
-            undo.append(undo_path)
+            try:
+                with codecs.open(new_path, 'r', 'utf-8') as f_new:
+                    with codecs.open(undo_path, 'w', 'utf-8') as f_undo:
+                        f_undo.write(f_new.read())
+                undo.append(undo_path)
+            except FileNotFoundError:
+                pass
 
             # restore redo file
-            with codecs.open(redo_path, 'r', 'utf-8') as f_redo:
-                with codecs.open(new_path, 'w', 'utf-8') as f_new:
-                    f_new.write(f_redo.read())
-            os.unlink(redo_path)
+            try:
+                with codecs.open(redo_path, 'r', 'utf-8') as f_redo:
+                    with codecs.open(new_path, 'w', 'utf-8') as f_new:
+                        f_new.write(f_redo.read())
+                os.unlink(redo_path)
+            except FileNotFoundError:
+                pass
 
         #reload DOM to make changes stick
         for name in ('applications', 'settings'):
@@ -221,7 +238,8 @@ class MenuEditor(object):
             except (IOError, xml.parsers.expat.ExpatError):
                 menu.dom = xml.dom.minidom.parseString(util.getUserMenuXml(menu.tree))
             util.removeWhitespaceNodes(menu.dom)
-        self.__undo.append(undo)
+        if undo:
+            self.__undo.append(undo)
 
     def getMenus(self, parent=None):
         if parent is None:


### PR DESCRIPTION
So I noticed that dragging & dropping a menu entry would duplicate it instead of move it. Turns out there were two moveItem() functions in the same namespace, which explains a lot of the confusion that was had the last time we tried to fix this and probably why it broke again or was never fully fixed.

This also fixes the undo and redo functions (Ctrl+Z and Ctrl+Shift+Z) in general - both broken file accesses plus wrong order of operations - plus in particular in combination with the moveItem() function, where multiple steps had to be merged into a single. 

Last but not least it fixes a crash when reloading the menu and cleans up some unused imports and variables I came across.

Remaining issues outside of the scope of this PR: While the Ctrl+Z and Ctrl+Shift+Z seem to be solid with this, I noticed that the context menu "revert" function isn't always getting activated and overall it might be a good idea to add Undo and Redo buttons to the GUI because otherwise the user thinks the Revert button is supposed to handle that (which it is not). 