### PR TITLE
make the collection menu item removeable

### DIFF
--- a/Mozo/MenuEditor.py
+++ b/Mozo/MenuEditor.py
@@ -268,7 +268,6 @@ class MenuEditor(object):
                 item_type = item_iter.next()
 
     def getContents(self, item):
-        class CollectionDirectoryException(Exception): pass
 
         contents = []
         item_iter = item.iter()
@@ -276,22 +275,18 @@ class MenuEditor(object):
 
         while item_type != MateMenu.TreeItemType.INVALID:
             item = None
-            try:
-                if item_type == MateMenu.TreeItemType.DIRECTORY:
-                    item = item_iter.get_directory()
-                    if item.get_menu_id() == 'Collection': raise CollectionDirectoryException()
-                elif item_type == MateMenu.TreeItemType.ENTRY:
-                    item = item_iter.get_entry()
-                elif item_type == MateMenu.TreeItemType.HEADER:
-                    item = item_iter.get_header()
-                elif item_type == MateMenu.TreeItemType.ALIAS:
-                    item = item_iter.get_alias()
-                elif item_type == MateMenu.TreeItemType.SEPARATOR:
-                    item = item_iter.get_separator()
-                if item:
-                    contents.append(item)
-            except CollectionDirectoryException:
-                pass
+            if item_type == MateMenu.TreeItemType.DIRECTORY:
+                item = item_iter.get_directory()
+            elif item_type == MateMenu.TreeItemType.ENTRY:
+                item = item_iter.get_entry()
+            elif item_type == MateMenu.TreeItemType.HEADER:
+                item = item_iter.get_header()
+            elif item_type == MateMenu.TreeItemType.ALIAS:
+                item = item_iter.get_alias()
+            elif item_type == MateMenu.TreeItemType.SEPARATOR:
+                item = item_iter.get_separator()
+            if item:
+                contents.append(item)
             item_type = item_iter.next()
         return contents
 


### PR DESCRIPTION
With this PR you are able to add/remove the collection menu item with mozo, but you can still not edit its content (as it is supposed to be).
Closes https://github.com/mate-desktop/mate-menus/issues/101.