### PR TITLE
Mozo/MainWindow.py: Use locale package in addition to gettext package.

### DIFF
--- a/Mozo/MainWindow.py
+++ b/Mozo/MainWindow.py
@@ -27,6 +27,7 @@ from gi.repository import MateMenu
 import html
 import os
 import gettext
+import locale
 import subprocess
 import filecmp
 import shutil
@@ -35,8 +36,10 @@ try:
     from Mozo import config
     gettext.bindtextdomain(config.GETTEXT_PACKAGE,config.localedir)
     gettext.textdomain(config.GETTEXT_PACKAGE)
+    locale.bindtextdomain(config.GETTEXT_PACKAGE,config.localedir)
+    locale.textdomain(config.GETTEXT_PACKAGE)
     GETTEXT_PACKAGE = config.GETTEXT_PACKAGE
-except:
+except Exception:
     GETTEXT_PACKAGE = "mozo"
 _ = gettext.gettext
 from Mozo.MenuEditor import MenuEditor


### PR DESCRIPTION
When I package mozo to guix system, I have faced the similar problem like below:

https://askubuntu.com/questions/140552/how-to-make-glade-load-translations-from-opt

for guix do not use "/usr/share/locale" directory.