### PR TITLE
Update window layout

### DIFF
--- a/data/mozo.ui
+++ b/data/mozo.ui
@@ -76,6 +76,7 @@
         <property name="margin-bottom">6</property>
         <property name="orientation">vertical</property>
         <property name="spacing">2</property>
+        <property name="border-width">1</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox">
             <property name="can-focus">False</property>
@@ -204,6 +205,7 @@
   </object>
   <object class="GtkDialog" id="mainwindow">
     <property name="can-focus">False</property>
+    <property name="border-width">5</property>
     <property name="title" translatable="yes">Main Menu</property>
     <property name="default-width">675</property>
     <property name="default-height">530</property>
@@ -215,10 +217,6 @@
     <child internal-child="vbox">
       <object class="GtkBox">
         <property name="can-focus">False</property>
-        <property name="margin-start">6</property>
-        <property name="margin-end">6</property>
-        <property name="margin-top">6</property>
-        <property name="margin-bottom">6</property>
         <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
@@ -316,6 +314,9 @@
           <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
+            <property name="margin-top">5</property>
+            <property name="margin-left">5</property>
+            <property name="margin-right">5</property>
             <child>
               <object class="GtkPaned">
                 <property name="visible">True</property>


### PR DESCRIPTION
Same as https://github.com/mate-desktop/mate-control-center/issues/785, but for **mozo**.
Tested by rebuilding Mate 1.26 Debian source package.

The idea is to have same layout (but without the notebook):
![1](https://github.com/user-attachments/assets/3c177ee2-90ed-4179-aa19-3a2fe8c7b331)

Result:
![2](https://github.com/user-attachments/assets/7d842db4-d6c4-4072-ae2d-35a09b000f2e)


For buttons: there are larger with mozo, it's because all buttons have the same width, not sure why, but why not.