### PR TITLE
Fix crash on distros due to missing GioUnix namespace

### DIFF
--- a/Mozo/MainWindow.py
+++ b/Mozo/MainWindow.py
@@ -20,6 +20,10 @@
 import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('Gdk', '3.0')
+try:
+    gi.require_version('GioUnix', '2.0')
+except ValueError:
+    pass
 gi.require_version('MateMenu', '2.0')
 from gi.repository import GLib, Gio
 from gi.repository import Gtk, Gdk, GdkPixbuf

--- a/Mozo/MenuEditor.py
+++ b/Mozo/MenuEditor.py
@@ -23,6 +23,10 @@ import xml.dom.minidom
 import xml.parsers.expat
 import locale
 import gi
+try:
+    gi.require_version('GioUnix', '2.0')
+except ValueError:
+    pass
 gi.require_version('MateMenu', '2.0')
 from gi.repository import MateMenu, GLib
 from Mozo import util

--- a/Mozo/util.py
+++ b/Mozo/util.py
@@ -22,6 +22,10 @@ import re
 import xml.dom.minidom
 import gi
 gi.require_version('Gtk', '3.0')
+try:
+    gi.require_version('GioUnix', '2.0')
+except ValueError:
+    pass
 gi.require_version('MateMenu', '2.0')
 from collections.abc import Sequence
 from gi.repository import GLib, Gtk, Gdk, GdkPixbuf


### PR DESCRIPTION
On some distros mozo crashes if GioUnix is not loaded first.

Fixes #101